### PR TITLE
Force TCP for DNS lookups

### DIFF
--- a/src/claws_xmpp_comp.erl
+++ b/src/claws_xmpp_comp.erl
@@ -89,7 +89,7 @@ resolve_hosts(Name) ->
     resolve_hosts(Name, a).
 
 resolve_hosts(Name, Type) ->
-    [inet:ntoa(X) || X <- inet_res:lookup(Name, any, Type)].
+    [inet:ntoa(X) || X <- inet_res:lookup(Name, any, Type, [{usevc, true}])].
 
 select_host(Name, Pref) ->
     select_host(Name, resolve_hosts(Name), Pref).


### PR DESCRIPTION
In order to enable responses larger than a UDP datagram size.

If a domain name resolves to multiple addresses, it might be the case that the DNS server will return only a subset of them. If we do the lookup via TCP, the server seems to return all of them, not just a subset.