### PR TITLE
SQS fixes

### DIFF
--- a/src/claws_aws_sqs.erl
+++ b/src/claws_aws_sqs.erl
@@ -124,8 +124,7 @@ send(Data, JID, ID) -> %% TODO not sure what to do with the ID in this context
 %% Util
 process_message(Message) ->
     case extract_body(Message) of
-        {ok, Json} ->
-            Body = maps:get(Json, ?SQS_BODY),
+        {ok, Body} ->
             case fxml_stream:parse_element(Body) of
                 {ok, XmlElement} ->
                     Via = #via{claws = ?MODULE},

--- a/src/claws_aws_sqs.erl
+++ b/src/claws_aws_sqs.erl
@@ -16,7 +16,7 @@
 }).
 
 %% API
--export([start_link/1, start_link/2, start_link/6]).
+-export([start_link/1, start_link/6]).
 
 %% gen_server callbacks
 -export([init/1,
@@ -42,10 +42,6 @@ start_link(QueueName) ->
             erlcloud_aws:default_config()
         end,
     gen_server:start_link({local, ?MODULE}, ?MODULE, {AwsConfig, QueueName}, []).
-
--spec start_link(aws_config(), module()) -> {ok, pid()}.
-start_link(AwsConfig, SqsModule) ->
-    gen_server:start_link({local, ?MODULE}, ?MODULE, {AwsConfig, SqsModule}, []).
 
 -spec start_link(aws_config(), integer(), integer(), string(), module(), integer()) -> {ok, pid()}.
 start_link(AwsConfig, MaxNumberOfMessages, PollInterval, QueueName, SqsModule, WaitTimeoutSeconds) ->

--- a/src/snatch.erl
+++ b/src/snatch.erl
@@ -5,7 +5,7 @@
 
 -include("snatch.hrl").
 
--type claws() :: claws_rabbitmq | claws_xmpp | claws_xmpp_comp.
+-type claws() :: claws_rabbitmq | claws_xmpp | claws_xmpp_comp | claws_aws_sqs.
 
 -record(state, {claws :: claws(),
                 callback :: module(),
@@ -102,7 +102,7 @@ disconnected(Data) ->
 
 -spec init([term()]) -> {ok, #state{}} | {stop, Reason :: atom()}.
 %% @doc initialize the snatch process. It could be only one per node.
-init([Claws, Module, Args]) ->    
+init([Claws, Module, Args]) ->
     case Module:init(Args) of
         {ok, State} ->
             {ok, #state{claws = Claws,

--- a/test/claws_aws_sqs_tests.erl
+++ b/test/claws_aws_sqs_tests.erl
@@ -28,7 +28,7 @@ stop(Pid) ->
     application:stop(snatch).
 
 test_process_message() ->
-    Contents = <<"<iq id=\"test-bot\" to=\"alice@localhost\" from=\"bob@localhost/pc\" type=\"get\"><query/></iq>">>,
+    Contents = "<iq id=\"test-bot\" to=\"alice@localhost\" from=\"bob@localhost/pc\" type=\"get\"><query/></iq>",
     Results = claws_aws_sqs:process_messages([{messages, [[{body, Contents}]]}]),
     Via = #via{claws = claws_aws_sqs},
     [

--- a/test/claws_aws_sqs_tests.erl
+++ b/test/claws_aws_sqs_tests.erl
@@ -11,6 +11,7 @@ claws_aws_sqs_send_message_test_() ->
      fun setup/0,
      fun stop/1,
      [
+        fun test_process_message/0,
         fun test_static_send_receive/0,
         fun test_snatch/0
      ]
@@ -25,6 +26,14 @@ stop(Pid) ->
     claws_aws_sqs_tests_mocks:stop(),
     gen_server:stop(Pid),
     application:stop(snatch).
+
+test_process_message() ->
+    Contents = <<"<iq id=\"test-bot\" to=\"alice@localhost\" from=\"bob@localhost/pc\" type=\"get\"><query/></iq>">>,
+    Results = claws_aws_sqs:process_message({message, [[{body, Contents}]]}),
+    Via = #via{claws = claws_aws_sqs},
+    [
+        ?_assertMatch([{ok, Contents, Via}], Results)
+    ].
 
 test_static_send_receive() ->
     QueueName = <<"test-queue">>,

--- a/test/claws_aws_sqs_tests.erl
+++ b/test/claws_aws_sqs_tests.erl
@@ -29,7 +29,7 @@ stop(Pid) ->
 
 test_process_message() ->
     Contents = <<"<iq id=\"test-bot\" to=\"alice@localhost\" from=\"bob@localhost/pc\" type=\"get\"><query/></iq>">>,
-    Results = claws_aws_sqs:process_message({message, [[{body, Contents}]]}),
+    Results = claws_aws_sqs:process_messages([{messages, [[{body, Contents}]]}]),
     Via = #via{claws = claws_aws_sqs},
     [
         ?_assertMatch([{ok, Contents, Via}], Results)

--- a/test/claws_aws_sqs_tests.erl
+++ b/test/claws_aws_sqs_tests.erl
@@ -18,8 +18,7 @@ claws_aws_sqs_send_message_test_() ->
 
 setup() ->
     ok = claws_aws_sqs_tests_mocks:init([]),
-    {ok, _} = application:ensure_all_started(snatch),
-    {ok, Pid} = claws_aws_sqs:start_link(#aws_config{}, claws_aws_sqs_tests_mocks),
+    {ok, Pid} = claws_aws_sqs:start_link(#aws_config{}, 1, 21000, "test-queue", claws_aws_sqs_tests_mocks, 20),
     Pid.
 
 stop(Pid) ->
@@ -31,7 +30,7 @@ test_static_send_receive() ->
     QueueName = <<"test-queue">>,
     Message = <<"<test-message/>">>,
     claws_aws_sqs:send(Message, QueueName),
-    {ok, Results} = claws_aws_sqs_tests_mocks:receive_message(QueueName, {}),
+    Results = claws_aws_sqs_tests_mocks:receive_message(QueueName, {}),
     [
         ?_assert(claws_aws_sqs_tests_mocks:was_message_sent(QueueName, Message)),
         ?_assert(lists:member(Message, Results))

--- a/test/claws_aws_sqs_tests_mocks.erl
+++ b/test/claws_aws_sqs_tests_mocks.erl
@@ -4,6 +4,7 @@
     init/1,
     new/2,
     receive_message/2,
+    receive_message/6,
     send_message/3,
     send_message/4,
     stop/0,
@@ -21,11 +22,11 @@ new(_Access, _Secret) ->
 
 send_message(QueueName, Message, _AwsConfig) ->
     ets:insert(?TABLE, {QueueName, Message}),
-    {ok, {message_id, "MockMessageId"}}.
+    [{message_id, "MockMessageId"}, {md5_of_message_body, "MockMD5"}].
 
 send_message(QueueName, Message, _MsgAttrs, _AwsConfig) ->
     ets:insert(?TABLE, {QueueName, Message}),
-    {ok, {message_id, "MockMessageId"}}.
+    [{message_id, "MockMessageId"}, {md5_of_message_body, "MockMD5"}].
 
 receive_message(QueueName, _AwsConfig) ->
     Messages = ets:lookup(?TABLE, QueueName),
@@ -35,8 +36,11 @@ receive_message(QueueName, _AwsConfig) ->
         (_) -> false
     end, Results) of
         true -> {error, process_message_failed};
-        _ -> {ok, Results}
+        _ -> Results
     end.
+
+receive_message(QueueName, _, _, _, _, AwsConfig) ->
+    receive_message(QueueName, AwsConfig).
 
 was_message_sent(QueueName, Message) ->
     Messages = ets:lookup(?TABLE, QueueName),


### PR DESCRIPTION
This fixes a few issues I discovered with Pedro.

1. `send` was pattern matching off the wrong AWS response
2. `receive` wasn't polling, which I missed initially because our test app just "received-then-exit". We made a new test app that's a more normal OTP application.
3. Fixes minor string/data handling

This branch was working in our newer test app, see: https://github.com/bholten/snatch_app